### PR TITLE
feat: 로테이션 페이지 구현

### DIFF
--- a/src/app/api/rotation-alluser/route.ts
+++ b/src/app/api/rotation-alluser/route.ts
@@ -1,0 +1,35 @@
+import { dataUrl, ROTATION_URL } from "@/services/apiUrl";
+import { Champion } from "@/types/Champions";
+import { RotationData } from "@/types/Rotations";
+
+//무료 챔피언 로테이션 for All users
+export async function GET() {
+  const RIOT_API_KEY = process.env.RIOT_API_KEY;
+  const headers: HeadersInit = {
+    "Content-Type": "application/json"
+  };
+
+  //API키가 있는 경우 / 없는 경우 분기처리
+  if (RIOT_API_KEY) {
+    headers["api_key"] = RIOT_API_KEY;
+  } else {
+    console.error("API-Key missing! : api/rotation-allusers/GET method");
+  }
+
+  //로테이션 데이터 가져오기
+  const resRotation = await fetch(`${ROTATION_URL}?api_key=${RIOT_API_KEY}`, {
+    headers
+  });
+  const dataRotation: RotationData = await resRotation.json();
+
+  // 챔피언 목록 데이터 가져오기
+  const resChampions = await fetch(`${dataUrl}/champion.json`);
+  const { data: dataChampions } = await resChampions.json();
+  const championList: Champion[] = Object.values(dataChampions);
+
+  const rotationListForAll: Champion[] = championList.filter((_, index) =>
+    dataRotation.freeChampionIds.includes(index)
+  );
+
+  return Response.json({ rotationListForAll });
+}

--- a/src/app/rotation/page.tsx
+++ b/src/app/rotation/page.tsx
@@ -1,5 +1,13 @@
+import RotationListForAll from "@/components/_/RotationListForAll";
+import RotationListForNew from "@/components/_/RotationListForNew";
+
 const rotationPage = () => {
-  return <div>rotationPage</div>;
+  return (
+    <div>
+      <RotationListForAll />
+      <RotationListForNew />
+    </div>
+  );
 };
 
 export default rotationPage;

--- a/src/components/_/RotationListForAll.tsx
+++ b/src/components/_/RotationListForAll.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Champion } from "@/types/Champions";
+import { useEffect, useState } from "react";
+import ChampionCard from "../ChampionCard";
+
+const RotationListForAll = () => {
+  const [rotationList, setRotationList] = useState<Champion[]>([]);
+
+  useEffect(() => {
+    fetch("/api/rotation-alluser")
+      .then((res) => res.json())
+      .then(({ rotationListForAll }) => {
+        setRotationList(rotationListForAll);
+      })
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h2>금주의 로테이션 - 모든 유저</h2>
+      {rotationList?.map((cham) => (
+        <ChampionCard key={cham.id} id={cham.id} cham={cham} />
+      ))}
+    </div>
+  );
+};
+
+export default RotationListForAll;

--- a/src/components/_/RotationListForNew.tsx
+++ b/src/components/_/RotationListForNew.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { getRotationForNew } from "@/server-action";
+import { Champion } from "@/types/Champions";
+import { useEffect, useState } from "react";
+import ChampionCard from "../ChampionCard";
+
+const RotationListForNew = () => {
+  const [rotationList, setRotationList] = useState<Champion[]>([]);
+
+  useEffect(() => {
+    getRotationForNew()
+      .then(({ rotationListForNew }) => {
+        console.log(rotationListForNew);
+        setRotationList(rotationListForNew);
+      })
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h2>금주의 로테이션 - Lv.10 이하</h2>
+      {rotationList?.map((cham) => (
+        <ChampionCard key={cham.id} id={cham.id} cham={cham} />
+      ))}
+    </div>
+  );
+};
+
+export default RotationListForNew;

--- a/src/server-action.ts
+++ b/src/server-action.ts
@@ -1,0 +1,23 @@
+import { dataUrl, ROTATION_URL } from "./services/apiUrl";
+import { Champion } from "./types/Champions";
+import { RotationData } from "./types/Rotations";
+
+//무료 챔피언 로테이션 for New users
+export const getRotationForNew = async () => {
+  //로테이션 데이터 가져오기
+  const resRotation = await fetch(
+    `${ROTATION_URL}?api_key=${process.env.NEXT_PUBLIC_RIOT_API_KEY}`
+  );
+  const data: RotationData = await resRotation.json();
+
+  //챔피언 목록 데이터 가져오기
+  const resChampions = await fetch(`${dataUrl}/champion.json`);
+  const { data: dataChampion } = await resChampions.json();
+  const championList: Champion[] = Object.values(dataChampion);
+
+  const rotationListForNew: Champion[] = championList.filter((_, index) =>
+    data.freeChampionIdsForNewPlayers.includes(index)
+  );
+
+  return { rotationListForNew };
+};

--- a/src/services/apiUrl.ts
+++ b/src/services/apiUrl.ts
@@ -14,3 +14,8 @@ export const championsSplashImgUrl: string =
 //챔피언 loading 이미지 url : ${champion.id}_0.jpg (Aatrox_0.jpg)
 export const championLoadingImgUrl: string =
   "https://ddragon.leagueoflegends.com/cdn/img/champion/loading";
+
+export const ROTATION_URL: string =
+  "https://kr.api.riotgames.com/lol/platform/v3/champion-rotations";
+
+export const BASE_URL: string = "http://localhost:3000";

--- a/src/types/Rotations.ts
+++ b/src/types/Rotations.ts
@@ -1,0 +1,5 @@
+export type RotationData = {
+  freeChampionIds: number[];
+  freeChampionIdsForNewPlayers: number[];
+  maxNewPlayerLevel: number;
+};


### PR DESCRIPTION
## 💡 ISSUE
✨ FEAT (#7): 로테이션 페이지 구현

<br/>

## 🔘 Part

- [x] FE

<br/>

## 🔎 작업 내용

- Route Handler, server-action 설계
- 클라이언트 컴포넌트에서 설계한 api end point 호출해서 데이터 패치
- CSR - “use client” 사용해서 챔피언 로테이션 리스트 컴포넌트 구현 (챔피언 로테이션 페이지는 서버 컴포넌트)

  <br/>

## 🖼️ 이미지 첨부 (선택)

- 로테이션 페이지 + route handler (모든 유저)
<img width="1440" alt="Screenshot 2025-03-14 at 7 14 11 PM" src="https://github.com/user-attachments/assets/3bf02645-ded3-4f34-8305-2d5a80927c76" />

- 로테이션 페이지 + server-action (신규 유저)
<img width="1440" alt="Screenshot 2025-03-14 at 7 14 22 PM" src="https://github.com/user-attachments/assets/15de7cb2-f6ac-452e-acf6-536cc33b9435" />

<br/>

## 💬 리뷰 요구사항 (선택)

> Route Handler / server-action에서 중복되는 로직 리팩토링
> `CSR`에서 TanStack Query로 상태관리 리팩토링

<br/>

### ✔️ 이슈 닫기

Closes #7